### PR TITLE
Infer verdict for each judge case in `run_judge`

### DIFF
--- a/judge-core/src/monitor.rs
+++ b/judge-core/src/monitor.rs
@@ -2,7 +2,9 @@ use crate::error::JudgeCoreError;
 use crate::result::{
     check_checker_result, check_user_result, get_max_mem, get_run_time, JudgeResultInfo,
 };
-use crate::sandbox::{ProcessListener, RawRunResultInfo, ResourceLimitConfig, SandBox};
+use crate::sandbox::{
+    ProcessListener, RawRunResultInfo, ResourceLimitConfig, SandBox, SCRIPT_LIMIT_CONFIG,
+};
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::sys::epoll::{
@@ -68,7 +70,7 @@ pub fn run_judge(runner_config: &RunnerConfig) -> Result<Option<JudgeResultInfo>
     let checker_spawn = checker_process.spawn(
         &runner_config.checker_path,
         &checker_args,
-        &runner_config.rlimit_config,
+        &SCRIPT_LIMIT_CONFIG,
     )?;
     if checker_spawn.is_none() {
         return Ok(None);
@@ -197,7 +199,7 @@ pub fn run_interact(
     let interact_spawn = interact_process.spawn_with_io(
         interactor_path,
         &interact_args,
-        &runner_config.rlimit_config,
+        &SCRIPT_LIMIT_CONFIG,
         interactor_read_proxy,
         interactor_write_proxy,
     )?;
@@ -248,7 +250,7 @@ pub fn run_interact(
     let checker_spawn = checker_process.spawn(
         &runner_config.checker_path,
         &checker_args,
-        &runner_config.rlimit_config,
+        &SCRIPT_LIMIT_CONFIG,
     )?;
 
     if checker_spawn.is_none() {

--- a/judge-core/src/monitor.rs
+++ b/judge-core/src/monitor.rs
@@ -241,7 +241,7 @@ pub mod monitor {
 
     const TEST_CONFIG: ResourceLimitConfig = ResourceLimitConfig {
         stack_limit: Some((64 * 1024 * 1024, 64 * 1024 * 1024)),
-        as_limit: Some((256 * 1024 * 1024, 256 * 1024 * 1024)),
+        as_limit: Some((64 * 1024 * 1024, 64 * 1024 * 1024)),
         cpu_limit: Some((1, 2)),
         nproc_limit: Some((1, 1)),
         fsize_limit: Some((1024, 1024)),
@@ -251,6 +251,40 @@ pub mod monitor {
     fn test_run_judge() {
         let runner_config = RunnerConfig {
             program_path: "./../test-collection/dist/programs/read_and_write".to_owned(),
+            checker_path: "./../test-collection/dist/checkers/lcmp".to_owned(),
+            input_file_path: "../tmp/in".to_owned(),
+            output_file_path: "../tmp/out".to_owned(),
+            answer_file_path: "../tmp/ans".to_owned(),
+            rlimit_config: TEST_CONFIG,
+        };
+        let result = run_judge(&runner_config);
+        assert!(result.is_ok());
+        if let Ok(Some(result)) = result {
+            log::info!("{:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_run_tle() {
+        let runner_config = RunnerConfig {
+            program_path: "./../test-collection/dist/programs/infinite_loop".to_owned(),
+            checker_path: "./../test-collection/dist/checkers/lcmp".to_owned(),
+            input_file_path: "../tmp/in".to_owned(),
+            output_file_path: "../tmp/out".to_owned(),
+            answer_file_path: "../tmp/ans".to_owned(),
+            rlimit_config: TEST_CONFIG,
+        };
+        let result = run_judge(&runner_config);
+        assert!(result.is_ok());
+        if let Ok(Some(result)) = result {
+            log::info!("{:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_run_mle() {
+        let runner_config = RunnerConfig {
+            program_path: "./../test-collection/dist/programs/memory_limit".to_owned(),
             checker_path: "./../test-collection/dist/checkers/lcmp".to_owned(),
             input_file_path: "../tmp/in".to_owned(),
             output_file_path: "../tmp/out".to_owned(),

--- a/judge-core/src/monitor.rs
+++ b/judge-core/src/monitor.rs
@@ -49,8 +49,8 @@ pub fn run_judge(runner_config: &RunnerConfig) -> Result<Option<JudgeResultInfo>
             verdict,
             time: user_time,
             memory: max_mem,
-            exit_code: user_result.exit_code,
-            checker_exit_code: 0,
+            exit_status: user_result.exit_status,
+            checker_exit_status: 0,
         }));
     }
 
@@ -77,8 +77,8 @@ pub fn run_judge(runner_config: &RunnerConfig) -> Result<Option<JudgeResultInfo>
         verdict,
         time: user_time,
         memory: max_mem,
-        exit_code: user_result.exit_code,
-        checker_exit_code: checker_result.exit_code,
+        exit_status: user_result.exit_status,
+        checker_exit_status: checker_result.exit_status,
     }))
 }
 

--- a/judge-core/src/monitor.rs
+++ b/judge-core/src/monitor.rs
@@ -18,6 +18,7 @@ pub struct RunnerConfig {
     pub input_file_path: String,
     pub output_file_path: String,
     pub answer_file_path: String,
+    pub check_file_path: String,
     pub rlimit_config: ResourceLimitConfig,
 }
 
@@ -61,6 +62,7 @@ pub fn run_judge(runner_config: &RunnerConfig) -> Result<Option<JudgeResultInfo>
         &runner_config.input_file_path,
         &runner_config.output_file_path,
         &runner_config.answer_file_path,
+        &runner_config.check_file_path,
     ];
 
     let checker_spawn = checker_process.spawn(
@@ -240,6 +242,7 @@ pub fn run_interact(
         &runner_config.input_file_path,
         &runner_config.output_file_path,
         &runner_config.answer_file_path,
+        &runner_config.check_file_path,
     ];
     log::info!("Spawning checker process");
     let checker_spawn = checker_process.spawn(
@@ -277,6 +280,7 @@ pub mod monitor {
             input_file_path: "../tmp/in".to_owned(),
             output_file_path: "../tmp/out".to_owned(),
             answer_file_path: "../tmp/ans".to_owned(),
+            check_file_path: "../tmp/check".to_owned(),
             rlimit_config: TEST_CONFIG,
         };
         let result = run_judge(&runner_config);
@@ -295,6 +299,7 @@ pub mod monitor {
             input_file_path: "../tmp/in".to_owned(),
             output_file_path: "../tmp/out".to_owned(),
             answer_file_path: "../tmp/ans".to_owned(),
+            check_file_path: "../tmp/check".to_owned(),
             rlimit_config: TEST_CONFIG,
         };
         let result = run_judge(&runner_config);
@@ -313,6 +318,7 @@ pub mod monitor {
             input_file_path: "../tmp/in".to_owned(),
             output_file_path: "../tmp/out".to_owned(),
             answer_file_path: "../tmp/ans".to_owned(),
+            check_file_path: "../tmp/check".to_owned(),
             rlimit_config: TEST_CONFIG,
         };
         let result = run_judge(&runner_config);
@@ -331,6 +337,7 @@ pub mod monitor {
             input_file_path: "../tmp/in".to_owned(),
             output_file_path: "../tmp/out".to_owned(),
             answer_file_path: "../tmp/ans".to_owned(),
+            check_file_path: "../tmp/check".to_owned(),
             rlimit_config: TEST_CONFIG,
         };
         let result = run_interact(

--- a/judge-core/src/result.rs
+++ b/judge-core/src/result.rs
@@ -47,6 +47,7 @@ pub fn check_checker_result(raw_info: &RawRunResultInfo) -> JudgeVerdict {
     let exit_status = raw_info.exit_status;
     match exit_status {
         0 => JudgeVerdict::Accepted,
+        256 => JudgeVerdict::WrongAnswer,
         _ => JudgeVerdict::SystemError,
     }
 }

--- a/judge-core/src/result.rs
+++ b/judge-core/src/result.rs
@@ -5,8 +5,8 @@ pub struct JudgeResultInfo {
     pub verdict: JudgeVerdict,
     pub time: i64,
     pub memory: i64,
-    pub exit_code: i32,
-    pub checker_exit_code: i32,
+    pub exit_status: i32,
+    pub checker_exit_status: i32,
 }
 
 #[derive(Debug, PartialEq)]

--- a/judge-core/src/result.rs
+++ b/judge-core/src/result.rs
@@ -1,33 +1,52 @@
-use crate::{monitor::RunnerConfig, sandbox::RawRunResultInfo};
-use std::collections::HashSet;
+use crate::sandbox::RawRunResultInfo;
 
 #[derive(Debug)]
 pub struct JudgeResultInfo {
-    pub raw: RawRunResultInfo,
-    pub problems: HashSet<JudgeProblemType>,
+    pub verdict: JudgeVerdict,
+    pub time: i64,
+    pub memory: i64,
+    pub exit_code: i32,
+    pub checker_exit_code: i32,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
-pub enum JudgeProblemType {
-    SystemError,
+#[derive(Debug, PartialEq)]
+pub enum JudgeVerdict {
+    Accepted,
+    WrongAnswer,
+    TimeLimitExceeded,
+    IdlenessLimitExceeded,
     RuntimeError,
-    MemoryLimitExceeded,
-    RealTimeLimitExceeded,
-    CpuTimeLimitExceeded,
+    PartialScore,
+    SystemError,
 }
 
-pub fn infer_result(raw_info: RawRunResultInfo, _runner_config: RunnerConfig) -> JudgeResultInfo {
-    let mut problems = HashSet::new();
+pub fn get_run_time(raw_info: &RawRunResultInfo) -> i64 {
+    let rusage = raw_info.resource_usage;
+    let utime = rusage.ru_utime.tv_sec * 1000 + rusage.ru_utime.tv_usec / 1000;
+    let stime = rusage.ru_utime.tv_sec * 1000 + rusage.ru_utime.tv_usec / 1000;
+    utime + stime
+}
 
-    // TODO: Fullfill problem infer
-    if raw_info.exit_signal == libc::SIGUSR1 {
-        problems.insert(JudgeProblemType::SystemError);
-    } else if raw_info.exit_code != 0 {
-        problems.insert(JudgeProblemType::RuntimeError);
+pub fn get_max_mem(raw_info: &RawRunResultInfo) -> i64 {
+    let rusage = raw_info.resource_usage;
+    rusage.ru_maxrss
+}
+
+pub fn check_user_result(raw_info: &RawRunResultInfo) -> Option<JudgeVerdict> {
+    let exit_status = raw_info.exit_status;
+    match exit_status {
+        0 => None,
+        11 => Some(JudgeVerdict::RuntimeError),
+        152 => Some(JudgeVerdict::TimeLimitExceeded),
+        _ => Some(JudgeVerdict::SystemError),
     }
+}
 
-    JudgeResultInfo {
-        raw: raw_info,
-        problems,
+pub fn check_checker_result(raw_info: &RawRunResultInfo) -> JudgeVerdict {
+    // TODO: return verdict according to the checker output
+    let exit_status = raw_info.exit_status;
+    match exit_status {
+        0 => JudgeVerdict::Accepted,
+        _ => JudgeVerdict::SystemError,
     }
 }

--- a/judge-core/src/sandbox.rs
+++ b/judge-core/src/sandbox.rs
@@ -110,7 +110,7 @@ impl SandBox {
         Ok(())
     }
 
-    pub fn wait(&self) -> Result<Option<RawRunResultInfo>, JudgeCoreError> {
+    pub fn wait(&self) -> Result<RawRunResultInfo, JudgeCoreError> {
         let mut status: c_int = 0;
         let mut usage: rusage = get_default_rusage();
         unsafe {
@@ -119,13 +119,13 @@ impl SandBox {
 
         log::info!("Detected process pid={} exit", self.child_pid);
 
-        Ok(Some(RawRunResultInfo {
+        Ok(RawRunResultInfo {
             exit_status: status,
             exit_signal: WTERMSIG(status),
             exit_code: WEXITSTATUS(status),
             real_time_cost: self.begin_time.elapsed(),
             resource_usage: usage,
-        }))
+        })
     }
 
     pub fn spawn(

--- a/judge-core/src/sandbox.rs
+++ b/judge-core/src/sandbox.rs
@@ -21,6 +21,14 @@ pub struct ResourceLimitConfig {
     pub fsize_limit: Option<(u64, u64)>,
 }
 
+pub const SCRIPT_LIMIT_CONFIG: ResourceLimitConfig = ResourceLimitConfig {
+    stack_limit: Some((16 * 1024 * 1024, 16 * 1024 * 1024)),
+    as_limit: Some((1024 * 1024 * 1024, 1024 * 1024 * 1024)),
+    cpu_limit: Some((60, 90)),
+    nproc_limit: Some((1, 1)),
+    fsize_limit: Some((1024, 1024)),
+};
+
 #[derive(Debug)]
 pub struct RawRunResultInfo {
     pub exit_status: c_int,


### PR DESCRIPTION
For each test case, it is expected to run in function `run_judge`. Now the function will return a `JudgeResultInfo` with a verdict.
See more details in #88 .

BTW, a default resource limit is set for judge script.