### PR TITLE
Fix invalid package_path make judger always busy

### DIFF
--- a/judger/src/server/client/mod.rs
+++ b/judger/src/server/client/mod.rs
@@ -148,6 +148,7 @@ fn run_judge(task: JudgeTask) -> Result<Vec<JudgeResultInfo>, ClientError> {
         src_path: runtime_path.clone().join(&src_file_name),
     });
     if new_builder_result.is_err() {
+        state::set_idle();
         return Err(ClientError::InternalError(anyhow::anyhow!(
             "Failed to new builder result: {:?}",
             new_builder_result.err()


### PR DESCRIPTION
In the backend platform test, when the judger receives an invalid problem it will become always busy and not serve for another submission.

Just occurs especially when the `database` and `minio` are not consistent I think. 